### PR TITLE
Add ExchangeBerry (EXB) token

### DIFF
--- a/tronalliance.json
+++ b/tronalliance.json
@@ -209,3 +209,11 @@
 		}
 	]
 }
+{
+  "symbol": "EXB",
+  "name": "ExchangeBerry",
+  "address": "TJfwgDTDLqXHHaDPJtJAjnT6V1eZWGcGPX",
+  "chainId": 1,
+  "decimals": 6,
+  "logoURI": "https://raw.githubusercontent.com/exchangeberry/assets/master/blockchains/tron/assets/blockchains/tron/assets/TJfwgDTDLqXHHaDPJtJAjnT6V1eZWGcGPX/logo.png"
+}


### PR DESCRIPTION
This pull request adds ExchangeBerry (EXB) token to the Tron Alliance list.

Contract address: TJfwgDTDLqXHHaDPJtJAjnT6V1eZWGcGPX  
Logo URI: https://raw.githubusercontent.com/exchangeberry/assets/master/blockchains/tron/assets/TJfwgDTDLqXHHaDPJtJAjnT6V1eZWGcGPX/logo.png  
ChainID: 1  
Decimals: 6  
Symbol: EXB